### PR TITLE
Fix ConfigHandler missing remapping

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.20.1
 yarn_mappings=1.20.1+build.2
 loader_version=0.14.21
 # Mod Properties
-mod_version = 1.20.1-1
+mod_version = 1.20.1-2
 maven_group = com.daniking.backtools
 archives_base_name = backtools
 # Dependencies

--- a/src/main/java/com/daniking/backtools/BackTools.java
+++ b/src/main/java/com/daniking/backtools/BackTools.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
 public class BackTools implements ModInitializer {
 
 	public static final Logger LOGGER = LoggerFactory.getLogger(BackTools.class);
-	public static final String VERSION = "1.20-1";
+	public static final String VERSION = "1.20-2";
 
 	@Override
 	public void onInitialize() {


### PR DESCRIPTION
Fix ConfigHandler not being able to load remapped class names and therefor always getting the error `Could not find class to add orientation` outside of Dev environment.